### PR TITLE
Add a cache to the release scraper call in the test suite

### DIFF
--- a/tests/test_up_to_date.py
+++ b/tests/test_up_to_date.py
@@ -1,3 +1,4 @@
+import functools
 import os
 from pathlib import Path
 
@@ -22,6 +23,7 @@ PACKAGE_NAMES = [
 ]
 
 
+@functools.cache  # To avoid multiple API calls during testing
 def _get_whl_urls() -> list[str]:
     url = "https://api.github.com/repos/cgohlke/geospatial-wheels/releases"
     response = httpx.get(url, timeout=10)


### PR DESCRIPTION
This is to avoid 403 rate limiting in CI